### PR TITLE
feat: trigger KopsControlPlaneReconciler for changes in KopsMachinePool

### DIFF
--- a/controllers/infrastructure.cluster.x-k8s.io/kopsmachinepool_controller_test.go
+++ b/controllers/infrastructure.cluster.x-k8s.io/kopsmachinepool_controller_test.go
@@ -87,55 +87,6 @@ func TestGetInstanceGroupName(t *testing.T) {
 	}
 }
 
-func TestGetClusterByName(t *testing.T) {
-	testCases := []map[string]interface{}{
-		{
-			"description":     "Should successfully return cluster",
-			"expectedError":   false,
-			"clusterFunction": nil,
-		},
-		{
-			"description":   "Cluster don't exist, should return error",
-			"expectedError": true,
-			"clusterFunction": func(kopsCluster *clusterv1.Cluster) *clusterv1.Cluster {
-				return &clusterv1.Cluster{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "another-test-cluster",
-					},
-				}
-			},
-		},
-	}
-
-	RegisterFailHandler(Fail)
-	g := NewWithT(t)
-	ctx := context.TODO()
-
-	err := clusterv1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-	for _, tc := range testCases {
-		t.Run(tc["description"].(string), func(t *testing.T) {
-			cluster := newCluster("test-cluster", "", metav1.NamespaceDefault)
-			if tc["clusterFunction"] != nil {
-				clusterFunction := tc["clusterFunction"].(func(cluster *clusterv1.Cluster) *clusterv1.Cluster)
-				cluster = clusterFunction(cluster)
-			}
-			fakeClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(cluster).Build()
-			reconciler := &KopsMachinePoolReconciler{
-				Client: fakeClient,
-			}
-			cluster, err := reconciler.getClusterByName(ctx, metav1.NamespaceDefault, "test-cluster.k8s.cluster")
-			if !tc["expectedError"].(bool) {
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(cluster).NotTo(BeNil())
-			} else {
-				g.Expect(err).To(HaveOccurred())
-			}
-
-		})
-	}
-}
-
 func TestIsInstanceGroupCreated(t *testing.T) {
 
 	testCases := []map[string]interface{}{

--- a/go.mod
+++ b/go.mod
@@ -50,6 +50,7 @@ require (
 	k8s.io/apimachinery v0.22.2
 	k8s.io/client-go v0.22.2
 	k8s.io/kops v1.21.1
+	k8s.io/kubectl v0.22.2 // indirect
 	sigs.k8s.io/cluster-api v1.0.1
 	sigs.k8s.io/controller-runtime v0.10.3
 )

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1,0 +1,24 @@
+package util
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	clusterv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// GetClusterByName finds and return a Cluster object using the specified params.
+func GetClusterByName(ctx context.Context, c client.Client, namespace, name string) (*clusterv1beta1.Cluster, error) {
+	cluster := &clusterv1beta1.Cluster{}
+	key := client.ObjectKey{
+		Namespace: namespace,
+		Name:      name,
+	}
+
+	if err := c.Get(ctx, key, cluster); err != nil {
+		return nil, errors.Wrapf(err, "failed to get Cluster/%s", name)
+	}
+
+	return cluster, nil
+}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -1,0 +1,73 @@
+package util
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubectl/pkg/scheme"
+	clusterv1betav1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestGetClusterByName(t *testing.T) {
+	testCases := []struct {
+		description   string
+		clusters      []client.Object
+		expectedError bool
+	}{
+		{
+			description:   "Should successfully return cluster",
+			expectedError: false,
+			clusters: []client.Object{
+				newCluster("test-cluster", "", metav1.NamespaceDefault),
+			},
+		},
+		{
+			description:   "Cluster don't exist, should return error",
+			expectedError: true,
+			clusters:      nil,
+		},
+	}
+
+	RegisterFailHandler(Fail)
+	g := NewWithT(t)
+	ctx := context.TODO()
+
+	err := clusterv1betav1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(tc.clusters...).Build()
+			cluster, err := GetClusterByName(ctx, fakeClient, metav1.NamespaceDefault, "test-cluster.k8s.cluster")
+			if !tc.expectedError {
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(cluster).NotTo(BeNil())
+			} else {
+				g.Expect(err).To(HaveOccurred())
+			}
+
+		})
+	}
+}
+
+func newCluster(name, controlplane, namespace string) *clusterv1betav1.Cluster {
+	return &clusterv1betav1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      fmt.Sprintf("%s.k8s.cluster", name),
+		},
+		Spec: clusterv1betav1.ClusterSpec{
+			ControlPlaneRef: &corev1.ObjectReference{
+				Name:      controlplane,
+				Namespace: namespace,
+				Kind:      "KopsControlPlane",
+			},
+		},
+	}
+}


### PR DESCRIPTION
The purpose of this PR is to trigger the reconcile loop for KopsControlPlane when any KopsMachinePool related with it are modified