### PR TITLE
fix: infer the subnet using KopsControlPlane instead of KopsMachinePool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
-test: manifests generate fmt vet golangci-lint ## Run tests.
+test: manifests generate fmt vet lint ## Run tests.
 	@echo "> Running tests"
 	mkdir -p ${ENVTEST_ASSETS_DIR}
 	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.8.3/hack/setup-envtest.sh


### PR DESCRIPTION
This PR is intended to fix the wrong assumption that the subnets in the KopsMachinePool were a source of truth. Now we are using the Zone attribute from the KopsControlPlane's Subnets which are more reliable in that matter