### PR TITLE
fix: get kmp function to also consider the value

### DIFF
--- a/pkg/kops/kops.go
+++ b/pkg/kops/kops.go
@@ -3,7 +3,6 @@ package kops
 import (
 	"context"
 	"fmt"
-
 	kopsapi "k8s.io/kops/pkg/apis/kops"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -52,20 +51,19 @@ func GetKopsMachinePoolsWithLabel(ctx context.Context, c client.Client, key, val
 		return kmps, ErrLabelValueEmpty
 	}
 
+	selectors := []client.ListOption{
+		client.MatchingLabels{
+			key: value,
+		},
+	}
+
 	kmpsList := &kinfrastructurev1alpha1.KopsMachinePoolList{}
-	err := c.List(ctx, kmpsList)
+	err := c.List(ctx, kmpsList, selectors...)
 	if err != nil {
 		return kmps, fmt.Errorf("error while trying to retrieve KopsMachinePool list: %w", err)
 	}
 
-	// Todo: use label selector to avoid iterate over the items
-	for _, kmp := range kmpsList.Items {
-		if _, ok := kmp.Labels[key]; ok {
-			kmps = append(kmps, kmp)
-		}
-	}
-
-	return kmps, nil
+	return kmpsList.Items, nil
 }
 
 func GetAutoScalingGroupNameFromKopsMachinePool(kmp kinfrastructurev1alpha1.KopsMachinePool) (*string, error) {

--- a/pkg/kops/kops_test.go
+++ b/pkg/kops/kops_test.go
@@ -220,8 +220,21 @@ func TestGetKopsMachinePoolsWithLabel(t *testing.T) {
 
 	testCases := []testCase{
 		{
-			description:     "should return the correct machinepool set",
-			k8sObjects:      []client.Object{&kmp},
+			description: "should return the correct machinepool set",
+			k8sObjects: []client.Object{
+				&kmp,
+				&kinfrastructurev1alpha1.KopsMachinePool{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: metav1.NamespaceDefault,
+						Name:      "test-kops-machine-pool-b",
+						Labels: map[string]string{
+							"cluster.x-k8s.io/cluster-name": "test-cluster-b",
+						},
+					},
+					Spec: kinfrastructurev1alpha1.KopsMachinePoolSpec{
+						ClusterName: "test-cluster-b",
+					},
+				}},
 			input:           []string{"cluster.x-k8s.io/cluster-name", "test-cluster"},
 			expected:        []kinfrastructurev1alpha1.KopsMachinePool{kmp},
 			isErrorExpected: false,
@@ -268,7 +281,7 @@ func TestGetKopsMachinePoolsWithLabel(t *testing.T) {
 			kmps, err := GetKopsMachinePoolsWithLabel(ctx, fakeClient, input[0], input[1])
 			if !tc.isErrorExpected { // no error expected
 				g.Expect(err).To(BeNil())
-				g.Expect(len(kmps)).To(Equal(len(tc.expected)))
+				g.Expect(len(tc.expected)).To(Equal(len(kmps)))
 			} else {
 				g.Expect(err).ToNot(BeNil())
 				g.Expect(len(kmps)).To(Equal(0))


### PR DESCRIPTION
The goal of this PR is to fix the behavior of the GetKopsMachinePoolsWithLabel which does not consider the label's value.