### PR TITLE
refactor: setup hierarchy between the pause annotations

### DIFF
--- a/.kubernetes/manifests.yaml
+++ b/.kubernetes/manifests.yaml
@@ -21,7 +21,11 @@ spec:
     singular: kopsawscluster
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.paused
+      name: Paused
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: KopsAWSCluster is the Schema for the kopsawsclusters API
@@ -72,7 +76,11 @@ spec:
     singular: kopscontrolplane
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.paused
+      name: Paused
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: KopsControlPlane is the Schema for the kopscontrolplanes API
@@ -5627,6 +5635,11 @@ spec:
                 description: ErrorMessage indicates that there is a terminal problem
                   reconciling the state, and will be set to a descriptive error message.
                 type: string
+              paused:
+                default: false
+                description: Paused indicates that the controller is prevented from
+                  processing the KopsControlPlane and all its associated objects.
+                type: boolean
               ready:
                 default: false
                 description: Ready denotes that the API Server is ready to receive
@@ -6676,6 +6689,11 @@ spec:
                 description: ErrorMessage indicates that there is a terminal problem
                   reconciling the state, and will be set to a descriptive error message.
                 type: string
+              paused:
+                default: false
+                description: Paused indicates that the controller is prevented from
+                  processing the KopsMachinePool.
+                type: boolean
               ready:
                 default: false
                 description: Ready denotes that the API Server is ready to receive

--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v3.8.7
 CONTROLLER_TOOLS_VERSION ?= v0.9.2
-GOLANGCI_LINT_VERSION ?= v1.47.3
+GOLANGCI_LINT_VERSION ?= v1.50.0
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize

--- a/apis/controlplane/v1alpha1/kopscontrolplane_types.go
+++ b/apis/controlplane/v1alpha1/kopscontrolplane_types.go
@@ -30,7 +30,7 @@ const (
 	// KopsControlPlaneSecretsReadyCondition reports on the successful reconcile of the Kops Secrets
 	KopsControlPlaneSecretsReadyCondition clusterv1.ConditionType = "KopsControlPlaneSecretsReady"
 
-	// KopsterraformGenerationReadyCondition reports on the successful generation of Terraform files by Kops.
+	// KopsTerraformGenerationReadyCondition reports on the successful generation of Terraform files by Kops.
 	KopsTerraformGenerationReadyCondition clusterv1.ConditionType = "KopsTerraformGenerationReady"
 
 	// TerraformApplyReadyCondition reports on the successful apply of the Terraform files.
@@ -83,6 +83,11 @@ type KopsControlPlaneStatus struct {
 	// +kubebuilder:default=false
 	Ready bool `json:"ready,omitempty"`
 
+	// +kubebuilder:default=false
+	// Paused indicates that the controller is prevented from processing the KopsControlPlane and all its associated objects.
+	// +optional
+	Paused bool `json:"paused,omitempty"`
+
 	// ErrorMessage indicates that there is a terminal problem reconciling the
 	// state, and will be set to a descriptive error message.
 	// +optional
@@ -122,11 +127,11 @@ func init() {
 }
 
 // GetConditions returns the set of conditions for this object.
-func (cp *KopsControlPlane) GetConditions() clusterv1.Conditions {
-	return cp.Status.Conditions
+func (kcp *KopsControlPlane) GetConditions() clusterv1.Conditions {
+	return kcp.Status.Conditions
 }
 
 // SetConditions sets the conditions on this object.
-func (cp *KopsControlPlane) SetConditions(conditions clusterv1.Conditions) {
-	cp.Status.Conditions = conditions
+func (kcp *KopsControlPlane) SetConditions(conditions clusterv1.Conditions) {
+	kcp.Status.Conditions = conditions
 }

--- a/apis/controlplane/v1alpha1/kopscontrolplane_types.go
+++ b/apis/controlplane/v1alpha1/kopscontrolplane_types.go
@@ -103,6 +103,7 @@ type KopsControlPlaneStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:printcolumn:name="Paused",type="string",JSONPath=".status.paused"
 
 // KopsControlPlane is the Schema for the kopscontrolplanes API
 type KopsControlPlane struct {

--- a/apis/infrastructure/v1alpha1/kopsawscluster_types.go
+++ b/apis/infrastructure/v1alpha1/kopsawscluster_types.go
@@ -40,6 +40,7 @@ type KopsAWSClusterStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:printcolumn:name="Paused",type="string",JSONPath=".status.paused"
 
 // KopsAWSCluster is the Schema for the kopsawsclusters API
 type KopsAWSCluster struct {

--- a/apis/infrastructure/v1alpha1/kopsmachinepool_types.go
+++ b/apis/infrastructure/v1alpha1/kopsmachinepool_types.go
@@ -61,6 +61,11 @@ type KopsMachinePoolStatus struct {
 	// +kubebuilder:default=false
 	Ready bool `json:"ready,omitempty"`
 
+	// +kubebuilder:default=false
+	// Paused indicates that the controller is prevented from processing the KopsMachinePool.
+	// +optional
+	Paused bool `json:"paused,omitempty"`
+
 	// Replicas is the most recently observed number of replicas
 	// +optional
 	Replicas int32 `json:"replicas"`

--- a/config/crd/bases/controlplane.cluster.x-k8s.io_kopscontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_kopscontrolplanes.yaml
@@ -15,7 +15,11 @@ spec:
     singular: kopscontrolplane
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.paused
+      name: Paused
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: KopsControlPlane is the Schema for the kopscontrolplanes API

--- a/config/crd/bases/controlplane.cluster.x-k8s.io_kopscontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_kopscontrolplanes.yaml
@@ -5570,6 +5570,11 @@ spec:
                 description: ErrorMessage indicates that there is a terminal problem
                   reconciling the state, and will be set to a descriptive error message.
                 type: string
+              paused:
+                default: false
+                description: Paused indicates that the controller is prevented from
+                  processing the KopsControlPlane and all its associated objects.
+                type: boolean
               ready:
                 default: false
                 description: Ready denotes that the API Server is ready to receive

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_kopsawsclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_kopsawsclusters.yaml
@@ -15,7 +15,11 @@ spec:
     singular: kopsawscluster
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.paused
+      name: Paused
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: KopsAWSCluster is the Schema for the kopsawsclusters API

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_kopsmachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_kopsmachinepools.yaml
@@ -1030,6 +1030,11 @@ spec:
                 description: ErrorMessage indicates that there is a terminal problem
                   reconciling the state, and will be set to a descriptive error message.
                 type: string
+              paused:
+                default: false
+                description: Paused indicates that the controller is prevented from
+                  processing the KopsMachinePool.
+                type: boolean
               ready:
                 default: false
                 description: Ready denotes that the API Server is ready to receive

--- a/config/crd/output/apiextensions.k8s.io_v1_customresourcedefinition_kopsawsclusters.infrastructure.cluster.x-k8s.io.yaml
+++ b/config/crd/output/apiextensions.k8s.io_v1_customresourcedefinition_kopsawsclusters.infrastructure.cluster.x-k8s.io.yaml
@@ -14,7 +14,11 @@ spec:
     singular: kopsawscluster
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.paused
+      name: Paused
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: KopsAWSCluster is the Schema for the kopsawsclusters API

--- a/config/crd/output/apiextensions.k8s.io_v1_customresourcedefinition_kopscontrolplanes.controlplane.cluster.x-k8s.io.yaml
+++ b/config/crd/output/apiextensions.k8s.io_v1_customresourcedefinition_kopscontrolplanes.controlplane.cluster.x-k8s.io.yaml
@@ -15,7 +15,11 @@ spec:
     singular: kopscontrolplane
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.paused
+      name: Paused
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: KopsControlPlane is the Schema for the kopscontrolplanes API

--- a/config/crd/output/apiextensions.k8s.io_v1_customresourcedefinition_kopscontrolplanes.controlplane.cluster.x-k8s.io.yaml
+++ b/config/crd/output/apiextensions.k8s.io_v1_customresourcedefinition_kopscontrolplanes.controlplane.cluster.x-k8s.io.yaml
@@ -5570,6 +5570,11 @@ spec:
                 description: ErrorMessage indicates that there is a terminal problem
                   reconciling the state, and will be set to a descriptive error message.
                 type: string
+              paused:
+                default: false
+                description: Paused indicates that the controller is prevented from
+                  processing the KopsControlPlane and all its associated objects.
+                type: boolean
               ready:
                 default: false
                 description: Ready denotes that the API Server is ready to receive

--- a/config/crd/output/apiextensions.k8s.io_v1_customresourcedefinition_kopsmachinepools.infrastructure.cluster.x-k8s.io.yaml
+++ b/config/crd/output/apiextensions.k8s.io_v1_customresourcedefinition_kopsmachinepools.infrastructure.cluster.x-k8s.io.yaml
@@ -1029,6 +1029,11 @@ spec:
                 description: ErrorMessage indicates that there is a terminal problem
                   reconciling the state, and will be set to a descriptive error message.
                 type: string
+              paused:
+                default: false
+                description: Paused indicates that the controller is prevented from
+                  processing the KopsMachinePool.
+                type: boolean
               ready:
                 default: false
                 description: Ready denotes that the API Server is ready to receive

--- a/controllers/controlplane/kopscontrolplane_controller.go
+++ b/controllers/controlplane/kopscontrolplane_controller.go
@@ -351,7 +351,6 @@ func (r *KopsControlPlaneReconciler) reconcileKubeconfig(ctx context.Context, ko
 //+kubebuilder:rbac:groups=cluster.x-k8s.io,resources=clusters/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups="",resources=events,verbs=get;list;watch;create;patch
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update
-//+kubebuilder:printcolumn:name="Paused",type="string",JSONPath=".status.paused"
 
 func (r *KopsControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, rerr error) {
 	r.log = ctrl.LoggerFrom(ctx)

--- a/controllers/infrastructure.cluster.x-k8s.io/kopsmachinepool_controller.go
+++ b/controllers/infrastructure.cluster.x-k8s.io/kopsmachinepool_controller.go
@@ -126,7 +126,6 @@ func getInstanceGroupNameFromKopsMachinePool(kopsMachinePool *infrastructurev1al
 //+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=kopsmachinepools,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=kopsmachinepools/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=kopsmachinepools/finalizers,verbs=update
-//+kubebuilder:printcolumn:name="Paused",type="string",JSONPath=".status.paused"
 
 func (r *KopsMachinePoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, rerr error) {
 	r.log = ctrl.LoggerFrom(ctx)


### PR DESCRIPTION
The goal of this PR to improve the usability of the pause annotation for the CRs. The idea is that when a resource in a higher hierarchy is paused then all the related resources are paused as well. In this case we decided the following hierarchy: cluster > kcp > kmp. So if a cluster object is paused, then the reconcile will also be stopped for the respective kcp and kmps. We are adding a paused status to improve the visibility of the status and also adding logs to be clear about which resource is causing it.