### PR TITLE
Use KMP name as IG name

### DIFF
--- a/controllers/infrastructure.cluster.x-k8s.io/kopsmachinepool_controller_test.go
+++ b/controllers/infrastructure.cluster.x-k8s.io/kopsmachinepool_controller_test.go
@@ -249,7 +249,7 @@ func TestKopsMachinePoolReconciler(t *testing.T) {
 			"asgNotFound":   true,
 		},
 		{
-			"description":             "Should faill if couldn't retrieve ASG and it's not a NotFound error",
+			"description":             "Should fail if couldn't retrieve ASG and it's not a NotFound error",
 			"kopsMachinePoolFunction": nil,
 			"getASGByTagFunction": func(kopsMachinePool *infrastructurev1alpha1.KopsMachinePool, _ *session.Session) (*autoscaling.Group, error) {
 				return nil, errors.New("error")


### PR DESCRIPTION
This PR changes the Kops Controller behavior to not rely on the cluster name for the IG name and use the KopsMachinePool meta name for it.

Before we had an invisible pattern, if the KopsMachinePool name didn't started with the cluster name, the controller would fail.

With this PR the kops-operator acts in the same way as the other Cluster-API providers.