### PR TITLE
fix: remove filter from DescribeAutoScalingGroups

### DIFF
--- a/.kubernetes/manifests.yaml
+++ b/.kubernetes/manifests.yaml
@@ -5328,7 +5328,7 @@ spec:
               optional: false
         - name: AWS_REGION
           value: us-east-1
-        image: tfgco/kubernetes-kops-operator:v0.2.0-alpha
+        image: tfgco/kubernetes-kops-operator:v0.3.0-alpha
         livenessProbe:
           httpGet:
             path: /healthz

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -16,4 +16,4 @@ images:
   newTag: latest
 - name: manager
   newName: tfgco/kubernetes-kops-operator
-  newTag: v0.2.0-alpha
+  newTag: v0.3.0-alpha

--- a/main.go
+++ b/main.go
@@ -146,7 +146,7 @@ func main() {
 		Scheme:                     mgr.GetScheme(),
 		Recorder:                   mgr.GetEventRecorderFor("kopsmachinepool-controller"),
 		ValidateKopsClusterFactory: utils.ValidateKopsCluster,
-		GetASGByTagFactory:         infrastructureclusterxk8siocontrollers.GetASGByTag,
+		GetASGByNameFactory:        infrastructureclusterxk8siocontrollers.GetASGByName,
 	}).SetupWithManager(ctx, mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "KopsMachinePool")
 		os.Exit(1)


### PR DESCRIPTION
This PR will fix the function to retrieve the ASG since the AWS API don't accept the usage of name and others filters