### PR TITLE
fix: always get kops client to avoid leak between reconciliations for kmp controller

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -38,7 +38,7 @@ jobs:
         go-version: 1.19.3
 
     - name: Install dependencies
-      run: sudo apt update && sudo apt install make -y
+      run: sudo apt install make -y
 
     - name: Run tests
       run: make test-ci

--- a/controllers/infrastructure.cluster.x-k8s.io/kopsmachinepool_controller_test.go
+++ b/controllers/infrastructure.cluster.x-k8s.io/kopsmachinepool_controller_test.go
@@ -259,6 +259,9 @@ func TestKopsMachinePoolReconciler(t *testing.T) {
 			reconciler := KopsMachinePoolReconciler{
 				Client:   fakeClient,
 				Recorder: record.NewFakeRecorder(5),
+				GetKopsClientSetFactory: func(configBase string) (simple.Clientset, error) {
+					return newFakeKopsClientset(), nil
+				},
 				ValidateKopsClusterFactory: func(kopsClientset simple.Clientset, kopsCluster *kopsapi.Cluster, igs *kopsapi.InstanceGroupList) (*validation.ValidationCluster, error) {
 					return &validation.ValidationCluster{}, nil
 				},
@@ -404,9 +407,11 @@ func TestKopsMachinePoolReconcilerSpotinst(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().WithObjects(kopsMachinePool, kopsControlPlane, cluster).WithScheme(scheme.Scheme).Build()
 
 			reconciler := KopsMachinePoolReconciler{
-				Client:        fakeClient,
-				kopsClientset: fakeKopsClientset,
-				Recorder:      record.NewFakeRecorder(5),
+				Client:   fakeClient,
+				Recorder: record.NewFakeRecorder(5),
+				GetKopsClientSetFactory: func(configBase string) (simple.Clientset, error) {
+					return fakeKopsClientset, nil
+				},
 				ValidateKopsClusterFactory: func(kopsClientset simple.Clientset, kopsCluster *kopsapi.Cluster, igs *kopsapi.InstanceGroupList) (*validation.ValidationCluster, error) {
 					return &validation.ValidationCluster{}, nil
 				},
@@ -588,8 +593,11 @@ func TestMachinePoolStatus(t *testing.T) {
 			}
 
 			reconciler := KopsMachinePoolReconciler{
-				Client:                     fakeClient,
-				Recorder:                   recorder,
+				Client:   fakeClient,
+				Recorder: recorder,
+				GetKopsClientSetFactory: func(configBase string) (simple.Clientset, error) {
+					return newFakeKopsClientset(), nil
+				},
 				ValidateKopsClusterFactory: validateKopsCluster,
 				GetASGByNameFactory: func(kopsMachinePool *infrastructurev1alpha1.KopsMachinePool, _ *session.Session) (*autoscaling.Group, error) {
 					return &autoscaling.Group{

--- a/main.go
+++ b/main.go
@@ -146,6 +146,7 @@ func main() {
 		Client:                     mgr.GetClient(),
 		Scheme:                     mgr.GetScheme(),
 		Recorder:                   mgr.GetEventRecorderFor("kopsmachinepool-controller"),
+		GetKopsClientSetFactory:    utils.GetKopsClientset,
 		ValidateKopsClusterFactory: utils.ValidateKopsCluster,
 		GetASGByNameFactory:        infrastructureclusterxk8siocontrollers.GetASGByName,
 	}).SetupWithManager(ctx, mgr); err != nil {


### PR DESCRIPTION
The goal of this PR is the same as the one before, this time is being applied in the kopsmachinepool controller as well