### PR TITLE
fix: add ignore changes to spotinst_ocean_aws to some of the fields

### DIFF
--- a/utils/templates/spotinst_ocean_aws_override.tf.tpl
+++ b/utils/templates/spotinst_ocean_aws_override.tf.tpl
@@ -1,0 +1,6 @@
+resource "spotinst_ocean_aws" "nodes-{{ stringReplace . "." "-" -1 }}" {
+    lifecycle {
+      ignore_changes = [autoscaler, desired_capacity, associate_public_ip_address, spot_percentage]
+    }
+    use_as_template_only = true
+}


### PR DESCRIPTION
The goal of this PR is to add ignore to some fields that we are unable to define using only the kops configurations i.e.: we don't want to changed the desired_capacity since spot should autoscale