### PR TITLE
feat: configure prune for karpenter addon provisioners

### DIFF
--- a/controllers/controlplane/kopscontrolplane_controller_test.go
+++ b/controllers/controlplane/kopscontrolplane_controller_test.go
@@ -1386,38 +1386,38 @@ func TestPrepareCustomCloudResources(t *testing.T) {
 			g.Expect(err).NotTo(HaveOccurred())
 			templatedBackendTF, err := os.ReadFile(templateTestDir + "/backend.tf")
 			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(generatedBackendTF).To(BeEquivalentTo(templatedBackendTF))
+			g.Expect(string(generatedBackendTF)).To(BeEquivalentTo(string(templatedBackendTF)))
 
 			generatedKarpenterBoostrapTF, err := os.ReadFile(terraformOutputDir + "/karpenter_custom_addon_boostrap.tf")
 			g.Expect(err).NotTo(HaveOccurred())
 			templatedKarpenterBoostrapTF, err := os.ReadFile(templateTestDir + "/karpenter_custom_addon_boostrap.tf")
 			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(generatedKarpenterBoostrapTF).To(BeEquivalentTo(templatedKarpenterBoostrapTF))
+			g.Expect(string(generatedKarpenterBoostrapTF)).To(BeEquivalentTo(string(templatedKarpenterBoostrapTF)))
 
 			generatedLaunchTemplateTF, err := os.ReadFile(terraformOutputDir + "/launch_template_override.tf")
 			g.Expect(err).NotTo(HaveOccurred())
 			templatedLaunchTemplateTF, err := os.ReadFile(templateTestDir + "/launch_template_override.tf")
 			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(generatedLaunchTemplateTF).To(BeEquivalentTo(templatedLaunchTemplateTF))
+			g.Expect(string(generatedLaunchTemplateTF)).To(BeEquivalentTo(string(templatedLaunchTemplateTF)))
 
 			generatedProvisionerContentTF, err := os.ReadFile(terraformOutputDir + "/data/aws_s3_object_karpenter_provisioners_content")
 			g.Expect(err).NotTo(HaveOccurred())
 			templatedProvisionerContentTF, err := os.ReadFile(templateTestDir + "/data/aws_s3_object_karpenter_provisioners_content")
 			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(generatedProvisionerContentTF).To(BeEquivalentTo(templatedProvisionerContentTF))
+			g.Expect(string(generatedProvisionerContentTF)).To(BeEquivalentTo(string(templatedProvisionerContentTF)))
 
 			if tc.spotInstEnabled {
 				generatedSpotinstLaunchSpecTF, err := os.ReadFile(terraformOutputDir + "/spotinst_launch_spec_override.tf")
 				g.Expect(err).NotTo(HaveOccurred())
 				templatedSpotinstLaunchSpecTF, err := os.ReadFile(templateTestDir + "/spotinst_launch_spec_override.tf")
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(generatedSpotinstLaunchSpecTF).To(BeEquivalentTo(templatedSpotinstLaunchSpecTF))
+				g.Expect(string(generatedSpotinstLaunchSpecTF)).To(BeEquivalentTo(string(templatedSpotinstLaunchSpecTF)))
 
 				generatedSpotinstOceanAWSTF, err := os.ReadFile(terraformOutputDir + "/spotinst_ocean_aws_override.tf")
 				g.Expect(err).NotTo(HaveOccurred())
 				templatedSpotinstOceanAWSTF, err := os.ReadFile(templateTestDir + "/spotinst_ocean_aws_override.tf")
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(generatedSpotinstOceanAWSTF).To(BeEquivalentTo(templatedSpotinstOceanAWSTF))
+				g.Expect(string(generatedSpotinstOceanAWSTF)).To(BeEquivalentTo(string(templatedSpotinstOceanAWSTF)))
 			}
 		})
 	}

--- a/utils/templates/karpenter_custom_addon_boostrap.tf.tpl
+++ b/utils/templates/karpenter_custom_addon_boostrap.tf.tpl
@@ -12,6 +12,11 @@ spec:
       k8s-addon: karpenter-provisioners.wildlife.io
     manifest: karpenter-provisioners.wildlife.io/provisioners.yaml
     manifestHash: "{{ .ManifestHash }}"
+    prune:
+      kinds:
+      - group: karpenter.sh
+        kind: Provisioner
+        labelSelector: "kops.k8s.io/managed-by=kops-controller"
 EOF
   key = "{{ .ClusterName }}/custom-addons/addon.yaml"
   provider = aws.files

--- a/utils/templates/tests/data/aws_s3_object_karpenter_provisioners_content
+++ b/utils/templates/tests/data/aws_s3_object_karpenter_provisioners_content
@@ -1,8 +1,17 @@
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  name: placeholder-karpenter-provisioners
+  namespace: kube-system
+---
 apiVersion: karpenter.sh/v1alpha5
 kind: Provisioner
 metadata:
   creationTimestamp: null
+  labels:
+    kops.k8s.io/managed-by: kops-controller
   name: test-provisioner
 spec:
   consolidation:

--- a/utils/templates/tests/karpenter_custom_addon_boostrap.tf
+++ b/utils/templates/tests/karpenter_custom_addon_boostrap.tf
@@ -11,7 +11,12 @@ spec:
     selector:
       k8s-addon: karpenter-provisioners.wildlife.io
     manifest: karpenter-provisioners.wildlife.io/provisioners.yaml
-    manifestHash: "785169a7d4ba0221779cd95ad7701652642e46b8408e641d54bacc100ab5fe9e"
+    manifestHash: "b3d32a0baf397c2f500b8936bad9e0581c6b234b7549d5aa624bc383722daaae"
+    prune:
+      kinds:
+      - group: karpenter.sh
+        kind: Provisioner
+        labelSelector: "kops.k8s.io/managed-by=kops-controller"
 EOF
   key = "test-cluster.test.k8s.cluster/custom-addons/addon.yaml"
   provider = aws.files


### PR DESCRIPTION
The goal of this PR is to configure prune for the Karpenter provisioners that are created using Kops' custom addons.The idea is that they will be removed from the remote cluster by protokube component when they are removed from the instance group configuration