### PR TITLE
Change requeue time to 1 hours, while we don't configure with configmap to avoid AWS api quota limit

### DIFF
--- a/controllers/controlplane/kopscontrolplane_controller.go
+++ b/controllers/controlplane/kopscontrolplane_controller.go
@@ -73,9 +73,10 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
+// TODO: fetch reconciliation configs from a configMap using kube API on each reconciliation
 var (
 	requeue1min   = ctrl.Result{RequeueAfter: 1 * time.Minute}
-	resultDefault = ctrl.Result{RequeueAfter: 20 * time.Minute}
+	resultDefault = ctrl.Result{RequeueAfter: 60 * time.Minute}
 	resultError   = ctrl.Result{RequeueAfter: 5 * time.Minute}
 )
 

--- a/controllers/controlplane/kopscontrolplane_controller_test.go
+++ b/controllers/controlplane/kopscontrolplane_controller_test.go
@@ -584,7 +584,7 @@ func TestKopsControlPlaneReconciler(t *testing.T) {
 				if tc.expectedRequeue {
 					g.Expect(result.RequeueAfter).To(Equal(time.Duration(1 * time.Minute)))
 				} else {
-					g.Expect(result.RequeueAfter).To(Equal(time.Duration(20 * time.Minute)))
+					g.Expect(result.RequeueAfter).To(Equal(time.Duration(60 * time.Minute)))
 				}
 
 				kopsCluster, err := fakeKopsClientset.GetCluster(ctx, cluster.GetObjectMeta().GetName())
@@ -870,7 +870,7 @@ func TestKopsControlPlaneStatus(t *testing.T) {
 			if !tc.expectedReconcilerError {
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(result.Requeue).To(BeFalse())
-				g.Expect(result.RequeueAfter).To(Equal(time.Duration(20 * time.Minute)))
+				g.Expect(result.RequeueAfter).To(Equal(time.Duration(60 * time.Minute)))
 			} else {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(result.RequeueAfter).To(Equal(time.Duration(5 * time.Minute)))


### PR DESCRIPTION
Change the default requeue time to 1 hour