### PR TITLE
fix: remove objects from reconciliation queue when it's managed by a different controller class

### DIFF
--- a/main.go
+++ b/main.go
@@ -143,6 +143,7 @@ func main() {
 	if err = (&controlplane.KopsControlPlaneReconciler{
 		Client:                           mgr.GetClient(),
 		Scheme:                           mgr.GetScheme(),
+		ControllerClass:                  controllerClass,
 		Mux:                              new(sync.Mutex),
 		Recorder:                         mgr.GetEventRecorderFor("kopscontrolplane-controller"),
 		TfExecPath:                       tfExecPath,
@@ -154,7 +155,7 @@ func main() {
 		ValidateKopsClusterFactory:       utils.ValidateKopsCluster,
 		GetClusterStatusFactory:          controlplane.GetClusterStatus,
 		GetASGByNameFactory:              controlplane.GetASGByName,
-	}).SetupWithManager(ctx, mgr, workers, controllerClass); err != nil {
+	}).SetupWithManager(ctx, mgr, workers); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "KopsControlPlane")
 		os.Exit(1)
 	}


### PR DESCRIPTION
The problem this PR is solving is that after the event enqueues a cluster to the reconciliation loop, the cluster is always requeued, even when the controllerClass of the cluster is changed. What the reconciliation is doing now is verifying the controllerClass at the beginning of each reconciliation and stoping the requeue when needed 