### PR TITLE
feat: add support to remove instance groups on kmp deletion

### DIFF
--- a/apis/controlplane/v1alpha1/kopscontrolplane_types.go
+++ b/apis/controlplane/v1alpha1/kopscontrolplane_types.go
@@ -53,6 +53,9 @@ const (
 
 	// TerraformApplyReconciliationFailedReason (Severity=Error) indicates that Terraform files couldn't be applied.
 	TerraformApplyReconciliationFailedReason = "TerraformApplyReconciliationFailed"
+
+	// FailedToUpdateKopsControlPlane (Severity=Warn) indicates that controller failed to update the custom resource.
+	FailedToUpdateKopsControlPlane = "FailedToUpdateKopsControlPlane"
 )
 
 type SpotInstSpec struct {

--- a/apis/infrastructure/v1alpha1/kopsmachinepool_types.go
+++ b/apis/infrastructure/v1alpha1/kopsmachinepool_types.go
@@ -31,6 +31,12 @@ const (
 const (
 	// KopsMachinePoolStateReconciliationFailedReason (Severity=Error) indicates that Kops state couldn't be created/updated.
 	KopsMachinePoolStateReconciliationFailedReason = "KopsMachinePoolStateReconciliationFailed"
+
+	// KopsMachinePoolFinalizer allows the controller to clean up resources on delete.
+	KopsMachinePoolFinalizer = "kopsmachinepool.infrastructure.cluster.x-k8s.io"
+
+	// FailedToUpdateKopsMachinePool (Severity=Warn) indicates that controller failed to update the custom resource.
+	FailedToUpdateKopsMachinePool = "FailedToUpdateKopsMachinePool"
 )
 
 // KopsMachinePoolSpec defines the desired state of KopsMachinePool

--- a/config/controlplane.cluster.x-k8s.io_kopscontrolplanes.yaml
+++ b/config/controlplane.cluster.x-k8s.io_kopscontrolplanes.yaml
@@ -1278,6 +1278,11 @@ spec:
                         description: Comma-delimited list of grace periods for each
                           soft eviction signal.  For example, 'memory.available=30s'.
                         type: string
+                      experimentalAllocatableIgnoreEviction:
+                        description: ExperimentalAllocatableIgnoreEviction enables
+                          ignoring Hard Eviction Thresholds while calculating Node
+                          Allocatable
+                        type: boolean
                       experimentalAllowedUnsafeSysctls:
                         description: ExperimentalAllowedUnsafeSysctls are passed to
                           the kubelet config to whitelist allowable sysctls Was promoted
@@ -2129,6 +2134,12 @@ spec:
                     properties:
                       enabled:
                         type: boolean
+                      image:
+                        type: string
+                      logFormat:
+                        type: string
+                      logLevel:
+                        type: string
                     type: object
                   keyStore:
                     description: KeyStore is the VFS path to where SSL keys and certificates
@@ -4377,6 +4388,11 @@ spec:
                         description: Comma-delimited list of grace periods for each
                           soft eviction signal.  For example, 'memory.available=30s'.
                         type: string
+                      experimentalAllocatableIgnoreEviction:
+                        description: ExperimentalAllocatableIgnoreEviction enables
+                          ignoring Hard Eviction Thresholds while calculating Node
+                          Allocatable
+                        type: boolean
                       experimentalAllowedUnsafeSysctls:
                         description: ExperimentalAllowedUnsafeSysctls are passed to
                           the kubelet config to whitelist allowable sysctls Was promoted
@@ -5197,6 +5213,10 @@ spec:
                               latency at the expense of up-front memory allocation.
                               Default: true'
                             type: boolean
+                          registry:
+                            description: Registry overrides the default Cilium container
+                              registry (quay.io)
+                            type: string
                           sidecarIstioProxyImage:
                             description: 'SidecarIstioProxyImage is the regular expression
                               matching compatible Istio sidecar istio-proxy container

--- a/config/crd/bases/controlplane.cluster.x-k8s.io_kopscontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_kopscontrolplanes.yaml
@@ -1278,6 +1278,11 @@ spec:
                         description: Comma-delimited list of grace periods for each
                           soft eviction signal.  For example, 'memory.available=30s'.
                         type: string
+                      experimentalAllocatableIgnoreEviction:
+                        description: ExperimentalAllocatableIgnoreEviction enables
+                          ignoring Hard Eviction Thresholds while calculating Node
+                          Allocatable
+                        type: boolean
                       experimentalAllowedUnsafeSysctls:
                         description: ExperimentalAllowedUnsafeSysctls are passed to
                           the kubelet config to whitelist allowable sysctls Was promoted
@@ -2129,6 +2134,12 @@ spec:
                     properties:
                       enabled:
                         type: boolean
+                      image:
+                        type: string
+                      logFormat:
+                        type: string
+                      logLevel:
+                        type: string
                     type: object
                   keyStore:
                     description: KeyStore is the VFS path to where SSL keys and certificates
@@ -4377,6 +4388,11 @@ spec:
                         description: Comma-delimited list of grace periods for each
                           soft eviction signal.  For example, 'memory.available=30s'.
                         type: string
+                      experimentalAllocatableIgnoreEviction:
+                        description: ExperimentalAllocatableIgnoreEviction enables
+                          ignoring Hard Eviction Thresholds while calculating Node
+                          Allocatable
+                        type: boolean
                       experimentalAllowedUnsafeSysctls:
                         description: ExperimentalAllowedUnsafeSysctls are passed to
                           the kubelet config to whitelist allowable sysctls Was promoted
@@ -5197,6 +5213,10 @@ spec:
                               latency at the expense of up-front memory allocation.
                               Default: true'
                             type: boolean
+                          registry:
+                            description: Registry overrides the default Cilium container
+                              registry (quay.io)
+                            type: string
                           sidecarIstioProxyImage:
                             description: 'SidecarIstioProxyImage is the regular expression
                               matching compatible Istio sidecar istio-proxy container

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_kopsmachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_kopsmachinepools.yaml
@@ -931,6 +931,11 @@ spec:
                         description: Comma-delimited list of grace periods for each
                           soft eviction signal.  For example, 'memory.available=30s'.
                         type: string
+                      experimentalAllocatableIgnoreEviction:
+                        description: ExperimentalAllocatableIgnoreEviction enables
+                          ignoring Hard Eviction Thresholds while calculating Node
+                          Allocatable
+                        type: boolean
                       experimentalAllowedUnsafeSysctls:
                         description: ExperimentalAllowedUnsafeSysctls are passed to
                           the kubelet config to whitelist allowable sysctls Was promoted

--- a/config/crd/output/apiextensions.k8s.io_v1_customresourcedefinition_kopscontrolplanes.controlplane.cluster.x-k8s.io.yaml
+++ b/config/crd/output/apiextensions.k8s.io_v1_customresourcedefinition_kopscontrolplanes.controlplane.cluster.x-k8s.io.yaml
@@ -987,6 +987,9 @@ spec:
                       evictionSoftGracePeriod:
                         description: Comma-delimited list of grace periods for each soft eviction signal.  For example, 'memory.available=30s'.
                         type: string
+                      experimentalAllocatableIgnoreEviction:
+                        description: ExperimentalAllocatableIgnoreEviction enables ignoring Hard Eviction Thresholds while calculating Node Allocatable
+                        type: boolean
                       experimentalAllowedUnsafeSysctls:
                         description: ExperimentalAllowedUnsafeSysctls are passed to the kubelet config to whitelist allowable sysctls Was promoted to beta and renamed. https://github.com/kubernetes/kubernetes/pull/63717
                         items:
@@ -1641,6 +1644,12 @@ spec:
                     properties:
                       enabled:
                         type: boolean
+                      image:
+                        type: string
+                      logFormat:
+                        type: string
+                      logLevel:
+                        type: string
                     type: object
                   keyStore:
                     description: KeyStore is the VFS path to where SSL keys and certificates are stored
@@ -3100,6 +3109,9 @@ spec:
                       evictionSoftGracePeriod:
                         description: Comma-delimited list of grace periods for each soft eviction signal.  For example, 'memory.available=30s'.
                         type: string
+                      experimentalAllocatableIgnoreEviction:
+                        description: ExperimentalAllocatableIgnoreEviction enables ignoring Hard Eviction Thresholds while calculating Node Allocatable
+                        type: boolean
                       experimentalAllowedUnsafeSysctls:
                         description: ExperimentalAllowedUnsafeSysctls are passed to the kubelet config to whitelist allowable sysctls Was promoted to beta and renamed. https://github.com/kubernetes/kubernetes/pull/63717
                         items:
@@ -3644,6 +3656,9 @@ spec:
                           preallocateBPFMaps:
                             description: 'PreallocateBPFMaps reduces the per-packet latency at the expense of up-front memory allocation. Default: true'
                             type: boolean
+                          registry:
+                            description: Registry overrides the default Cilium container registry (quay.io)
+                            type: string
                           sidecarIstioProxyImage:
                             description: 'SidecarIstioProxyImage is the regular expression matching compatible Istio sidecar istio-proxy container image names. Default: cilium/istio_proxy'
                             type: string

--- a/config/crd/output/apiextensions.k8s.io_v1_customresourcedefinition_kopsmachinepools.infrastructure.cluster.x-k8s.io.yaml
+++ b/config/crd/output/apiextensions.k8s.io_v1_customresourcedefinition_kopsmachinepools.infrastructure.cluster.x-k8s.io.yaml
@@ -711,6 +711,9 @@ spec:
                       evictionSoftGracePeriod:
                         description: Comma-delimited list of grace periods for each soft eviction signal.  For example, 'memory.available=30s'.
                         type: string
+                      experimentalAllocatableIgnoreEviction:
+                        description: ExperimentalAllocatableIgnoreEviction enables ignoring Hard Eviction Thresholds while calculating Node Allocatable
+                        type: boolean
                       experimentalAllowedUnsafeSysctls:
                         description: ExperimentalAllowedUnsafeSysctls are passed to the kubelet config to whitelist allowable sysctls Was promoted to beta and renamed. https://github.com/kubernetes/kubernetes/pull/63717
                         items:

--- a/config/infrastructure.cluster.x-k8s.io_kopsmachinepools.yaml
+++ b/config/infrastructure.cluster.x-k8s.io_kopsmachinepools.yaml
@@ -914,6 +914,11 @@ spec:
                         description: Comma-delimited list of grace periods for each
                           soft eviction signal.  For example, 'memory.available=30s'.
                         type: string
+                      experimentalAllocatableIgnoreEviction:
+                        description: ExperimentalAllocatableIgnoreEviction enables
+                          ignoring Hard Eviction Thresholds while calculating Node
+                          Allocatable
+                        type: boolean
                       experimentalAllowedUnsafeSysctls:
                         description: ExperimentalAllowedUnsafeSysctls are passed to
                           the kubelet config to whitelist allowable sysctls Was promoted

--- a/controllers/controlplane/kopscontrolplane_controller_test.go
+++ b/controllers/controlplane/kopscontrolplane_controller_test.go
@@ -390,7 +390,11 @@ func TestCreateOrUpdateKopsCluster(t *testing.T) {
 				},
 			}
 
-			err := reconciler.createOrUpdateKopsCluster(ctx, fakeKopsClientset, bareKopsCluster, dummySSHPublicKey, nil)
+			reconciliation := &KopsControlPlaneReconciliation{
+				KopsControlPlaneReconciler: *reconciler,
+			}
+
+			err := reconciliation.createOrUpdateKopsCluster(ctx, fakeKopsClientset, bareKopsCluster, dummySSHPublicKey, nil)
 			if !tc.expectedError {
 				g.Expect(err).NotTo(HaveOccurred())
 				cluster, err := fakeKopsClientset.GetCluster(ctx, bareKopsCluster.Name)
@@ -1378,7 +1382,7 @@ func TestCreateOrUpdateInstanceGroup(t *testing.T) {
 			}
 
 			reconciler := &KopsControlPlaneReconciliation{}
-			err = reconciler.createOrUpdateInstanceGroup(ctx, ctrl.LoggerFrom(ctx), fakeKopsClientset, kopsCluster, ig)
+			err = reconciler.createOrUpdateInstanceGroup(ctx, fakeKopsClientset, kopsCluster, ig)
 			if tc["expectedError"].(bool) {
 				g.Expect(err).To(HaveOccurred())
 				return

--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -119,7 +119,7 @@ func NewKopsControlPlane(name, namespace string) *controlplanev1alpha1.KopsContr
 				{
 					APIVersion: "cluster.x-k8s.io/v1beta1",
 					Kind:       "Cluster",
-					Name:       GetFQDN("testCluster"),
+					Name:       GetFQDN(name),
 				},
 			},
 		},


### PR DESCRIPTION
The goal of this PR is to add support to remove the Kops instance groups on reflection to the deletion of the KopsMachinePool resource