### PR TITLE
feat: add support do cluster addon in kopscontrolplane resource

### DIFF
--- a/.kubernetes/manifests.yaml
+++ b/.kubernetes/manifests.yaml
@@ -71,6 +71,9 @@ spec:
                 - name
                 - namespace
                 type: object
+              kopsClusterAddons:
+                description: 'KopsClusterAddons is intended to pass additional objects to the cluster: https://kops.sigs.k8s.io/addon_objects/#kubeschedulerconfiguration-group-kubeschedulerconfigk8sio'
+                type: string
               kopsClusterSpec:
                 description: 'KopsClusterSpec declare the desired Cluster Kops resource: https://kops.sigs.k8s.io/cluster_spec/'
                 properties:
@@ -994,6 +997,9 @@ spec:
                       evictionSoftGracePeriod:
                         description: Comma-delimited list of grace periods for each soft eviction signal.  For example, 'memory.available=30s'.
                         type: string
+                      experimentalAllocatableIgnoreEviction:
+                        description: ExperimentalAllocatableIgnoreEviction enables ignoring Hard Eviction Thresholds while calculating Node Allocatable
+                        type: boolean
                       experimentalAllowedUnsafeSysctls:
                         description: ExperimentalAllowedUnsafeSysctls are passed to the kubelet config to whitelist allowable sysctls Was promoted to beta and renamed. https://github.com/kubernetes/kubernetes/pull/63717
                         items:
@@ -1648,6 +1654,12 @@ spec:
                     properties:
                       enabled:
                         type: boolean
+                      image:
+                        type: string
+                      logFormat:
+                        type: string
+                      logLevel:
+                        type: string
                     type: object
                   keyStore:
                     description: KeyStore is the VFS path to where SSL keys and certificates are stored
@@ -3107,6 +3119,9 @@ spec:
                       evictionSoftGracePeriod:
                         description: Comma-delimited list of grace periods for each soft eviction signal.  For example, 'memory.available=30s'.
                         type: string
+                      experimentalAllocatableIgnoreEviction:
+                        description: ExperimentalAllocatableIgnoreEviction enables ignoring Hard Eviction Thresholds while calculating Node Allocatable
+                        type: boolean
                       experimentalAllowedUnsafeSysctls:
                         description: ExperimentalAllowedUnsafeSysctls are passed to the kubelet config to whitelist allowable sysctls Was promoted to beta and renamed. https://github.com/kubernetes/kubernetes/pull/63717
                         items:
@@ -3651,6 +3666,9 @@ spec:
                           preallocateBPFMaps:
                             description: 'PreallocateBPFMaps reduces the per-packet latency at the expense of up-front memory allocation. Default: true'
                             type: boolean
+                          registry:
+                            description: Registry overrides the default Cilium container registry (quay.io)
+                            type: string
                           sidecarIstioProxyImage:
                             description: 'SidecarIstioProxyImage is the regular expression matching compatible Istio sidecar istio-proxy container image names. Default: cilium/istio_proxy'
                             type: string
@@ -4888,6 +4906,9 @@ spec:
                       evictionSoftGracePeriod:
                         description: Comma-delimited list of grace periods for each soft eviction signal.  For example, 'memory.available=30s'.
                         type: string
+                      experimentalAllocatableIgnoreEviction:
+                        description: ExperimentalAllocatableIgnoreEviction enables ignoring Hard Eviction Thresholds while calculating Node Allocatable
+                        type: boolean
                       experimentalAllowedUnsafeSysctls:
                         description: ExperimentalAllowedUnsafeSysctls are passed to the kubelet config to whitelist allowable sysctls Was promoted to beta and renamed. https://github.com/kubernetes/kubernetes/pull/63717
                         items:
@@ -5709,7 +5730,7 @@ spec:
               optional: true
         - name: AWS_REGION
           value: us-east-1
-        image: tfgco/kubernetes-kops-operator:v0.7.0-alpha
+        image: tfgco/kubernetes-kops-operator:v0.8.0-alpha
         livenessProbe:
           httpGet:
             path: /healthz

--- a/apis/controlplane/v1alpha1/kopscontrolplane_types.go
+++ b/apis/controlplane/v1alpha1/kopscontrolplane_types.go
@@ -82,6 +82,8 @@ type KopsControlPlaneSpec struct {
 	// SpotInst enables Spot and define their feature flags
 	// +optional
 	SpotInst SpotInstSpec `json:"spotInst,omitempty"`
+	// KopsClusterAddons is intended to pass additional objects to the cluster: https://kops.sigs.k8s.io/addon_objects/#kubeschedulerconfiguration-group-kubeschedulerconfigk8sio
+	KopsClusterAddons string `json:"kopsClusterAddons,omitempty"`
 }
 
 type IdentityRefSpec struct {

--- a/config/controlplane.cluster.x-k8s.io_kopscontrolplanes.yaml
+++ b/config/controlplane.cluster.x-k8s.io_kopscontrolplanes.yaml
@@ -70,6 +70,10 @@ spec:
                 - name
                 - namespace
                 type: object
+              kopsClusterAddons:
+                description: 'KopsClusterAddons is intended to pass additional objects
+                  to the cluster: https://kops.sigs.k8s.io/addon_objects/#kubeschedulerconfiguration-group-kubeschedulerconfigk8sio'
+                type: string
               kopsClusterSpec:
                 description: 'KopsClusterSpec declare the desired Cluster Kops resource:
                   https://kops.sigs.k8s.io/cluster_spec/'

--- a/config/crd/bases/controlplane.cluster.x-k8s.io_kopscontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_kopscontrolplanes.yaml
@@ -70,6 +70,10 @@ spec:
                 - name
                 - namespace
                 type: object
+              kopsClusterAddons:
+                description: 'KopsClusterAddons is intended to pass additional objects
+                  to the cluster: https://kops.sigs.k8s.io/addon_objects/#kubeschedulerconfiguration-group-kubeschedulerconfigk8sio'
+                type: string
               kopsClusterSpec:
                 description: 'KopsClusterSpec declare the desired Cluster Kops resource:
                   https://kops.sigs.k8s.io/cluster_spec/'

--- a/config/crd/output/apiextensions.k8s.io_v1_customresourcedefinition_kopscontrolplanes.controlplane.cluster.x-k8s.io.yaml
+++ b/config/crd/output/apiextensions.k8s.io_v1_customresourcedefinition_kopscontrolplanes.controlplane.cluster.x-k8s.io.yaml
@@ -64,6 +64,9 @@ spec:
                 - name
                 - namespace
                 type: object
+              kopsClusterAddons:
+                description: 'KopsClusterAddons is intended to pass additional objects to the cluster: https://kops.sigs.k8s.io/addon_objects/#kubeschedulerconfiguration-group-kubeschedulerconfigk8sio'
+                type: string
               kopsClusterSpec:
                 description: 'KopsClusterSpec declare the desired Cluster Kops resource: https://kops.sigs.k8s.io/cluster_spec/'
                 properties:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -16,4 +16,4 @@ images:
   newTag: latest
 - name: manager
   newName: tfgco/kubernetes-kops-operator
-  newTag: v0.7.0-alpha
+  newTag: v0.8.0-alpha


### PR DESCRIPTION
The goal of this PR is to add support to specify cluster addons in the KopsControlPlane spec following [this](https://kops.sigs.k8s.io/addon_objects/). The motivation for this is to be able to apply KubeSchedulerConfiguration to the clusters