### PR TITLE
fix: update tag name of custom metrics

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -12,7 +12,7 @@ var (
 		prometheus.GaugeOpts{
 			Name: "custom_reconciliation_consecutive_errors_total",
 			Help: "Total number of consecutive reconciliation errors labeled by controller, cluster and environment",
-		}, []string{"controller", "cluster_name", "cluster_environment"},
+		}, []string{"controller", "object_name", "object_environment"},
 	)
 )
 


### PR DESCRIPTION
The PR is to change the tag name of the custom metric as it conflicts with the tags used by Datadog