### PR TITLE
fix: remove nodePool.spec.disruption.budgets from current version

### DIFF
--- a/controllers/controlplane/kopscontrolplane_controller.go
+++ b/controllers/controlplane/kopscontrolplane_controller.go
@@ -232,6 +232,12 @@ func (r *KopsControlPlaneReconciler) PrepareCustomCloudResources(ctx context.Con
 				nodePool.SetLabels(map[string]string{
 					"kops.k8s.io/managed-by": "kops-controller",
 				})
+
+				// TODO: remove this after upgrading to Karpenter 0.37
+				// This is needed because of the mismatch between the current karpenter version 0.32.4
+				// and the dependency version
+				nodePool.Spec.Disruption.Budgets = nil
+
 				// Create NodePool
 				if _, err := karpenterResourcesContent.Write([]byte("---\n")); err != nil {
 					return err


### PR DESCRIPTION
The goal of this PR is to remove the nodePool.spec.disruption.budgets because of a mismatch with the current version 0.32.4 that we are using. When we upgrade the controller, the idea is to remove this 