### PR TITLE
fix: add KubernetesCluster tag to NodePool template

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -16,4 +16,4 @@ images:
   newTag: latest
 - name: manager
   newName: tfgco/kubernetes-kops-operator
-  newTag: v0.13.2-alpha
+  newTag: v0.14.1-alpha

--- a/controllers/controlplane/kopscontrolplane_controller_test.go
+++ b/controllers/controlplane/kopscontrolplane_controller_test.go
@@ -2054,7 +2054,7 @@ func TestPrepareCustomCloudResources(t *testing.T) {
 				return kmp
 			},
 			karpenterResourcesOutput: "karpenter_resource_output_node_pool.yaml",
-			manifestHash:             "21e937a12016f39a20f07651d3ebe5e70b312a627379d2d05c154260dd0ab87c",
+			manifestHash:             "fafd4cc950ced952b36d97283ad300c72ca70ea8935e0efae7d88665a8115495",
 		},
 		{
 			description: "Should generate files based on template with one NodePool and one Provisioner",
@@ -2202,7 +2202,7 @@ func TestPrepareCustomCloudResources(t *testing.T) {
 				return kmp
 			},
 			karpenterResourcesOutput: "karpenter_resource_output_node_pool_and_provisioner.yaml",
-			manifestHash:             "38f8e21d8e1bedd7867e6300bfe2afada9c8908c06d05eecdc482d960dd4f338",
+			manifestHash:             "fd8c2593eaae4b5f6952282d1c8de40300afdbe2a2bcfe7c66a294e8899ec93c",
 		},
 		{
 			description: "Should generate files based on with spotinst enabled",

--- a/utils/fixtures/karpenter/test_successful_ec2_node_class.tpl
+++ b/utils/fixtures/karpenter/test_successful_ec2_node_class.tpl
@@ -26,5 +26,6 @@ spec:
     Name: test-cluster.test.k8s.cluster/test-machine-pool
     k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node: ''
     kops.k8s.io/instancegroup: test-machine-pool
+    KubernetesCluster: test-cluster.test.k8s.cluster
   userData: |
     dummy content

--- a/utils/templates/ec2nodeclass.yaml.tpl
+++ b/utils/templates/ec2nodeclass.yaml.tpl
@@ -26,6 +26,7 @@ spec:
     Name: {{ .ClusterName }}/{{ .IGName }}
     k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node: ''
     kops.k8s.io/instancegroup: {{ .IGName }}
+    KubernetesCluster: {{ .ClusterName }}
   {{- range $key, $value := .Tags }}
     {{ $key }}: {{ $value | quote }}
   {{- end }}

--- a/utils/templates/tests/data/karpenter_resource_output_node_pool.yaml
+++ b/utils/templates/tests/data/karpenter_resource_output_node_pool.yaml
@@ -85,5 +85,6 @@ spec:
     Name: test-cluster.test.k8s.cluster/test-ig
     k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node: ''
     kops.k8s.io/instancegroup: test-ig
+    KubernetesCluster: test-cluster.test.k8s.cluster
   userData: |
     dummy content

--- a/utils/templates/tests/data/karpenter_resource_output_node_pool_and_provisioner.yaml
+++ b/utils/templates/tests/data/karpenter_resource_output_node_pool_and_provisioner.yaml
@@ -134,5 +134,6 @@ spec:
     Name: test-cluster.test.k8s.cluster/test-ig
     k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node: ''
     kops.k8s.io/instancegroup: test-ig
+    KubernetesCluster: test-cluster.test.k8s.cluster
   userData: |
     dummy content


### PR DESCRIPTION
The goal of this PR is to add the KubernetesCluster tag to the NodePool template