### PR TITLE
Add support node pool budget

### DIFF
--- a/controllers/controlplane/kopscontrolplane_controller.go
+++ b/controllers/controlplane/kopscontrolplane_controller.go
@@ -233,11 +233,6 @@ func (r *KopsControlPlaneReconciler) PrepareCustomCloudResources(ctx context.Con
 					"kops.k8s.io/managed-by": "kops-controller",
 				})
 
-				// TODO: remove this after upgrading to Karpenter 0.37
-				// This is needed because of the mismatch between the current karpenter version 0.32.4
-				// and the dependency version
-				nodePool.Spec.Disruption.Budgets = nil
-
 				// Create NodePool
 				if _, err := karpenterResourcesContent.Write([]byte("---\n")); err != nil {
 					return err

--- a/controllers/controlplane/kopscontrolplane_controller_test.go
+++ b/controllers/controlplane/kopscontrolplane_controller_test.go
@@ -1987,6 +1987,16 @@ func TestPrepareCustomCloudResources(t *testing.T) {
 						},
 						Spec: karpenterv1beta1.NodePoolSpec{
 							Disruption: karpenterv1beta1.Disruption{
+								Budgets: []karpenterv1beta1.Budget{
+									{
+										Nodes: "10%",
+									},
+									{
+										Nodes:    "0",
+										Schedule: helpers.StringPtr("0 * * * *"),
+										Duration: &metav1.Duration{Duration: 40 * time.Minute},
+									},
+								},
 								ConsolidationPolicy: karpenterv1beta1.ConsolidationPolicyWhenUnderutilized,
 							},
 							Template: karpenterv1beta1.NodeClaimTemplate{

--- a/utils/fixtures/karpenter/test_successful_ec2_node_class.tpl
+++ b/utils/fixtures/karpenter/test_successful_ec2_node_class.tpl
@@ -13,6 +13,7 @@ spec:
     httpProtocolIPv6: disabled
     httpPutResponseHopLimit: 3
     httpTokens: required
+  associatePublicIPAddress: false
   blockDeviceMappings:
   - deviceName: /dev/sda1
     ebs:

--- a/utils/karpenter_utils.go
+++ b/utils/karpenter_utils.go
@@ -90,22 +90,31 @@ func CreateEC2NodeClassFromKopsLaunchTemplateInfo(kopsCluster *kopsapi.Cluster, 
 		return "", err
 	}
 
+	var associatePublicIP bool
+	if kmp.Spec.KopsInstanceGroupSpec.AssociatePublicIP != nil {
+		associatePublicIP = *kmp.Spec.KopsInstanceGroupSpec.AssociatePublicIP
+	} else {
+		associatePublicIP = false
+	}
+
 	data := struct {
-		Name        string
-		AmiName     string
-		ClusterName string
-		IGName      string
-		Tags        map[string]string
-		RootVolume  *karpenterv1beta1.BlockDevice
-		UserData    string
+		Name              string
+		AmiName           string
+		ClusterName       string
+		IGName            string
+		Tags              map[string]string
+		RootVolume        *karpenterv1beta1.BlockDevice
+		UserData          string
+		AssociatePublicIP bool
 	}{
-		Name:        nodePoolName,
-		AmiName:     amiName,
-		IGName:      kmp.Name,
-		ClusterName: kopsCluster.Name,
-		Tags:        kopsCluster.Spec.CloudLabels,
-		RootVolume:  BuildKarpenterVolumeConfigFromKops(kmp.Spec.KopsInstanceGroupSpec.RootVolume),
-		UserData:    userData,
+		Name:              nodePoolName,
+		AmiName:           amiName,
+		IGName:            kmp.Name,
+		ClusterName:       kopsCluster.Name,
+		Tags:              kopsCluster.Spec.CloudLabels,
+		RootVolume:        BuildKarpenterVolumeConfigFromKops(kmp.Spec.KopsInstanceGroupSpec.RootVolume),
+		UserData:          userData,
+		AssociatePublicIP: associatePublicIP,
 	}
 
 	content, err := templates.ReadFile("templates/ec2nodeclass.yaml.tpl")

--- a/utils/templates/ec2nodeclass.yaml.tpl
+++ b/utils/templates/ec2nodeclass.yaml.tpl
@@ -13,6 +13,7 @@ spec:
     httpProtocolIPv6: disabled
     httpPutResponseHopLimit: 3
     httpTokens: required
+  associatePublicIPAddress: {{ .AssociatePublicIP }}
   blockDeviceMappings:
   - deviceName: /dev/sda1
     ebs:

--- a/utils/templates/tests/data/karpenter_resource_output_node_pool.yaml
+++ b/utils/templates/tests/data/karpenter_resource_output_node_pool.yaml
@@ -15,6 +15,11 @@ metadata:
   name: test-node-pool
 spec:
   disruption:
+    budgets:
+    - nodes: 10%
+    - duration: 40m0s
+      nodes: "0"
+      schedule: 0 * * * *
     consolidationPolicy: WhenUnderutilized
     expireAfter: Never
   template:

--- a/utils/templates/tests/data/karpenter_resource_output_node_pool.yaml
+++ b/utils/templates/tests/data/karpenter_resource_output_node_pool.yaml
@@ -72,6 +72,7 @@ spec:
     httpProtocolIPv6: disabled
     httpPutResponseHopLimit: 3
     httpTokens: required
+  associatePublicIPAddress: false
   blockDeviceMappings:
   - deviceName: /dev/sda1
     ebs:

--- a/utils/templates/tests/data/karpenter_resource_output_node_pool_and_provisioner.yaml
+++ b/utils/templates/tests/data/karpenter_resource_output_node_pool_and_provisioner.yaml
@@ -121,6 +121,7 @@ spec:
     httpProtocolIPv6: disabled
     httpPutResponseHopLimit: 3
     httpTokens: required
+  associatePublicIPAddress: false
   blockDeviceMappings:
   - deviceName: /dev/sda1
     ebs:


### PR DESCRIPTION
The goal of this PR is to add support to configure the NodePool disruption.budgets, this is only possible after upgrading karpenter to +0.34 version