### PR TITLE
chore: improve logging of cluster deletion process

### DIFF
--- a/controllers/controlplane/kopscontrolplane_controller.go
+++ b/controllers/controlplane/kopscontrolplane_controller.go
@@ -100,7 +100,7 @@ type KopsControlPlaneReconciler struct {
 	PrepareKopsCloudResourcesFactory func(ctx context.Context, kopsClientset simple.Clientset, kopsCluster *kopsapi.Cluster, terraformOutputDir string, cloud fi.Cloud) error
 	ApplyTerraformFactory            func(ctx context.Context, terraformDir, tfExecPath string, credentials aws.Credentials) error
 	DestroyTerraformFactory          func(ctx context.Context, terraformDir, tfExecPath string, credentials aws.Credentials) error
-	KopsDeleteResourcesFactory       func(ctx context.Context, cloud fi.Cloud, kopsClientset simple.Clientset, kopsCluster *kopsapi.Cluster) error
+	KopsDeleteResourcesFactory       func(ctx context.Context, log logr.Logger, cloud fi.Cloud, kopsClientset simple.Clientset, kopsCluster *kopsapi.Cluster) error
 	ValidateKopsClusterFactory       func(kubeConfig *rest.Config, kopsCluster *kopsapi.Cluster, cloud fi.Cloud, igs *kopsapi.InstanceGroupList) (*validation.ValidationCluster, error)
 	GetClusterStatusFactory          func(kopsCluster *kopsapi.Cluster, cloud fi.Cloud) (*kopsapi.ClusterStatus, error)
 	GetASGByNameFactory              func(kopsMachinePool *infrastructurev1alpha1.KopsMachinePool, kopsControlPlane *controlplanev1alpha1.KopsControlPlane, credentials *aws.Credentials) (*asgTypes.AutoScalingGroup, error)
@@ -745,11 +745,13 @@ func (r *KopsControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			return resultError, err
 		}
 
+		log.Info(fmt.Sprintf("starting terraform destroy %s", owner.GetName()))
 		err = reconciler.DestroyTerraformFactory(ctx, terraformOutputDir, r.TfExecPath, reconciler.awsCredentials)
 		if err != nil {
 			reconciler.Recorder.Eventf(kopsControlPlane, corev1.EventTypeWarning, "FailedToDestroyTerraform", "failed to destroy terraform: %s", err)
 			return resultError, err
 		}
+		log.Info(fmt.Sprintf("finished terraform destroy %s", owner.GetName()))
 
 		reconciler.Mux.Lock()
 		shouldUnlock = true
@@ -775,10 +777,12 @@ func (r *KopsControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		// Decided to let the kops leftover deletion inside the lock as a safeguard
 		// since in the past they used to use singleton and as the deletion is not
 		// a common operation
-		err = r.KopsDeleteResourcesFactory(ctx, cloud, kopsClientset, kopsCluster)
+		log.Info(fmt.Sprintf("starting kops delete %s", owner.GetName()))
+		err = r.KopsDeleteResourcesFactory(ctx, log, cloud, kopsClientset, kopsCluster)
 		if err != nil {
 			return resultError, err
 		}
+		log.Info(fmt.Sprintf("finished kops delete %s", owner.GetName()))
 
 		reconciler.Mux.Unlock()
 		shouldUnlock = false

--- a/controllers/controlplane/kopscontrolplane_controller_test.go
+++ b/controllers/controlplane/kopscontrolplane_controller_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/go-logr/logr"
 	dto "github.com/prometheus/client_model/go"
 
 	karpenterv1beta1 "sigs.k8s.io/karpenter/pkg/apis/v1beta1"
@@ -1187,7 +1188,7 @@ func TestKopsControlPlaneReconcilerDelete(t *testing.T) {
 				DestroyTerraformFactory: func(ctx context.Context, terraformDir, tfExecPath string, credentials aws.Credentials) error {
 					return nil
 				},
-				KopsDeleteResourcesFactory: func(ctx context.Context, cloud fi.Cloud, kopsClientset simple.Clientset, kopsCluster *kopsapi.Cluster) error {
+				KopsDeleteResourcesFactory: func(ctx context.Context, log logr.Logger, cloud fi.Cloud, kopsClientset simple.Clientset, kopsCluster *kopsapi.Cluster) error {
 					return nil
 				},
 			}


### PR DESCRIPTION
This PR enhances the logging capabilities during the cluster deletion process to improve observability and debugging. Added logging statements to track the progress of:
   - Terraform destroy operations
   - Kops resource deletion
   - Cloud resource cleanup