### PR TITLE
Configurable terraform versions

### DIFF
--- a/controllers/controlplane/kopscontrolplane_controller.go
+++ b/controllers/controlplane/kopscontrolplane_controller.go
@@ -95,6 +95,7 @@ type KopsControlPlaneReconciler struct {
 	Recorder                         record.EventRecorder
 	TfExecPath                       string
 	DryRun                           bool
+	AWSProviderVersion               string
 	GetKopsClientSetFactory          func(configBase string) (simple.Clientset, error)
 	BuildCloudFactory                func(*kopsapi.Cluster) (fi.Cloud, error)
 	PopulateClusterSpecFactory       func(ctx context.Context, kopsCluster *kopsapi.Cluster, kopsClientset simple.Clientset, cloud fi.Cloud) (*kopsapi.Cluster, error)
@@ -937,6 +938,14 @@ func (r *KopsControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	err = reconciler.PrepareCustomCloudResources(ctx, kopsCluster, kopsControlPlane, existingKopsMachinePool, shouldEnableKarpenter, fullCluster.Spec.ConfigStore.Base, terraformOutputDir, shouldIgnoreSG)
 	if err != nil {
 		return resultError, err
+	}
+
+	// Modify existing Terraform files to add AWS provider version constraint if specified
+	if r.AWSProviderVersion != "" {
+		err = utils.ModifyTerraformProviderVersion(terraformOutputDir, r.AWSProviderVersion)
+		if err != nil {
+			return resultError, err
+		}
 	}
 
 	// Only Apply resources if DryRun isn't set from command line

--- a/main.go
+++ b/main.go
@@ -71,6 +71,7 @@ func main() {
 	var probeAddr string
 	var controllerClass string
 	var dryRun bool
+	var awsProviderVersion string
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
@@ -78,6 +79,7 @@ func main() {
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.StringVar(&controllerClass, "controller-class", "", "The name of the controller class to associate with the controller.")
 	flag.BoolVar(&dryRun, "dry-run", false, "Enable dry-run mode to plan without making actual changes.")
+	flag.StringVar(&awsProviderVersion, "aws-provider-version", "", "The version of the AWS provider to use in Terraform templates.")
 
 	opts := zap.Options{
 		Development: true,
@@ -85,6 +87,12 @@ func main() {
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
+
+	if awsProviderVersion == "" {
+		awsProviderVersion = "6.13.0"
+	}
+
+	setupLog.Info("Using AWS provider version", "version", awsProviderVersion)
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
@@ -162,6 +170,7 @@ func main() {
 		Recorder:                         recorder,
 		TfExecPath:                       tfExecPath,
 		DryRun:                           dryRun,
+		AWSProviderVersion:               awsProviderVersion,
 		GetKopsClientSetFactory:          utils.GetKopsClientset,
 		BuildCloudFactory:                utils.BuildCloud,
 		PopulateClusterSpecFactory:       controlplane.PopulateClusterSpec,

--- a/pkg/utils/fixtures/terraform/kubernetes_basic.tf
+++ b/pkg/utils/fixtures/terraform/kubernetes_basic.tf
@@ -1,0 +1,32 @@
+locals {
+  cluster_name                 = "test-cluster.us-east-1.k8s.example.com"
+  region                       = "us-east-1"
+  vpc_id                       = aws_vpc.test-cluster-us-east-1-k8s-example-com.id
+}
+
+output "cluster_name" {
+  value = "test-cluster.us-east-1.k8s.example.com"
+}
+
+output "region" {
+  value = "us-east-1"
+}
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+provider "aws" {
+  alias  = "files"
+  region = "us-east-1"
+}
+
+terraform {
+  required_version = ">= 0.15.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.71.0"
+    }
+  }
+}

--- a/pkg/utils/fixtures/terraform/kubernetes_basic_expected.tf
+++ b/pkg/utils/fixtures/terraform/kubernetes_basic_expected.tf
@@ -1,0 +1,32 @@
+locals {
+  cluster_name                 = "test-cluster.us-east-1.k8s.example.com"
+  region                       = "us-east-1"
+  vpc_id                       = aws_vpc.test-cluster-us-east-1-k8s-example-com.id
+}
+
+output "cluster_name" {
+  value = "test-cluster.us-east-1.k8s.example.com"
+}
+
+output "region" {
+  value = "us-east-1"
+}
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+provider "aws" {
+  alias  = "files"
+  region = "us-east-1"
+}
+
+terraform {
+  required_version = ">= 0.15.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0.0"
+    }
+  }
+}

--- a/pkg/utils/fixtures/terraform/kubernetes_exact_version.tf
+++ b/pkg/utils/fixtures/terraform/kubernetes_exact_version.tf
@@ -1,0 +1,33 @@
+locals {
+  cluster_name                 = "prod-cluster.us-east-1.k8s.example.com"
+  region                       = "us-east-1"
+  vpc_id                       = aws_vpc.prod-cluster-us-east-1-k8s-example-com.id
+  masters_role_arn             = aws_iam_role.masters-prod-cluster-us-east-1-k8s-example-com.arn
+  nodes_role_arn               = aws_iam_role.nodes-prod-cluster-us-east-1-k8s-example-com.arn
+}
+
+output "cluster_name" {
+  value = "prod-cluster.us-east-1.k8s.example.com"
+}
+
+output "masters_role_arn" {
+  value = aws_iam_role.masters-prod-cluster-us-east-1-k8s-example-com.arn
+}
+
+output "nodes_role_arn" {
+  value = aws_iam_role.nodes-prod-cluster-us-east-1-k8s-example-com.arn
+}
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+terraform {
+  required_version = ">= 0.15.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "4.67.0"
+    }
+  }
+}

--- a/pkg/utils/fixtures/terraform/kubernetes_exact_version_expected.tf
+++ b/pkg/utils/fixtures/terraform/kubernetes_exact_version_expected.tf
@@ -1,0 +1,33 @@
+locals {
+  cluster_name                 = "prod-cluster.us-east-1.k8s.example.com"
+  region                       = "us-east-1"
+  vpc_id                       = aws_vpc.prod-cluster-us-east-1-k8s-example-com.id
+  masters_role_arn             = aws_iam_role.masters-prod-cluster-us-east-1-k8s-example-com.arn
+  nodes_role_arn               = aws_iam_role.nodes-prod-cluster-us-east-1-k8s-example-com.arn
+}
+
+output "cluster_name" {
+  value = "prod-cluster.us-east-1.k8s.example.com"
+}
+
+output "masters_role_arn" {
+  value = aws_iam_role.masters-prod-cluster-us-east-1-k8s-example-com.arn
+}
+
+output "nodes_role_arn" {
+  value = aws_iam_role.nodes-prod-cluster-us-east-1-k8s-example-com.arn
+}
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+terraform {
+  required_version = ">= 0.15.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.0.0"
+    }
+  }
+}

--- a/pkg/utils/fixtures/terraform/kubernetes_no_aws_provider.tf
+++ b/pkg/utils/fixtures/terraform/kubernetes_no_aws_provider.tf
@@ -1,0 +1,22 @@
+locals {
+  cluster_name = "azure-cluster.eastus.k8s.example.com"
+  region       = "eastus"
+}
+
+output "cluster_name" {
+  value = "azure-cluster.eastus.k8s.example.com"
+}
+
+provider "azurerm" {
+  features {}
+}
+
+terraform {
+  required_version = ">= 0.15.0"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 3.0.0"
+    }
+  }
+}

--- a/pkg/utils/fixtures/terraform/kubernetes_quoted_version.tf
+++ b/pkg/utils/fixtures/terraform/kubernetes_quoted_version.tf
@@ -1,0 +1,34 @@
+locals {
+  cluster_name                 = "staging-cluster.us-east-1.k8s.example.com"
+  region                       = "us-east-1"
+  vpc_id                       = aws_vpc.staging-cluster-us-east-1-k8s-example-com.id
+  masters_role_arn             = aws_iam_role.masters-staging-cluster-us-east-1-k8s-example-com.arn
+}
+
+output "cluster_name" {
+  value = "staging-cluster.us-east-1.k8s.example.com"
+}
+
+output "masters_role_arn" {
+  value = aws_iam_role.masters-staging-cluster-us-east-1-k8s-example-com.arn
+}
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+provider "aws" {
+  alias  = "files"  
+  region = "us-east-1"
+}
+
+terraform {
+  required_version = ">= 0.15.0"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      "version" = ">= 4.50.0"
+      configuration_aliases = [aws.files]
+    }
+  }
+}

--- a/pkg/utils/fixtures/terraform/kubernetes_quoted_version_expected.tf
+++ b/pkg/utils/fixtures/terraform/kubernetes_quoted_version_expected.tf
@@ -1,0 +1,34 @@
+locals {
+  cluster_name                 = "staging-cluster.us-east-1.k8s.example.com"
+  region                       = "us-east-1"
+  vpc_id                       = aws_vpc.staging-cluster-us-east-1-k8s-example-com.id
+  masters_role_arn             = aws_iam_role.masters-staging-cluster-us-east-1-k8s-example-com.arn
+}
+
+output "cluster_name" {
+  value = "staging-cluster.us-east-1.k8s.example.com"
+}
+
+output "masters_role_arn" {
+  value = aws_iam_role.masters-staging-cluster-us-east-1-k8s-example-com.arn
+}
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+provider "aws" {
+  alias  = "files"  
+  region = "us-east-1"
+}
+
+terraform {
+  required_version = ">= 0.15.0"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      "version" = ">= 5.50.0"
+      configuration_aliases = [aws.files]
+    }
+  }
+}

--- a/pkg/utils/fixtures/terraform_basic_aws_provider.tf
+++ b/pkg/utils/fixtures/terraform_basic_aws_provider.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}


### PR DESCRIPTION
- Added support for configuring the AWS Terraform provider version via command line argument --aws-provider-version
- Added support for configuring the Terraform version via command line argument --terraform-version
- Shows AWS provider, Terraform, and kOps versions at startup