### PR TITLE
fix: properly retrieve cloud labels from kmp alonside with the kcp ones

### DIFF
--- a/controllers/controlplane/kopscontrolplane_controller_test.go
+++ b/controllers/controlplane/kopscontrolplane_controller_test.go
@@ -2017,6 +2017,12 @@ func TestPrepareCustomCloudResources(t *testing.T) {
 				kmp.Spec.KopsInstanceGroupSpec.NodeLabels = map[string]string{
 					"kops.k8s.io/instance-group-role": "Node",
 				}
+				kmp.Spec.KopsInstanceGroupSpec.CloudLabels = map[string]string{
+					"KubernetesCluster": "test-cluster.test.k8s.cluster",
+					"Name":              "test-cluster.test.k8s.cluster/test-ig",
+					"k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node": "",
+					"kops.k8s.io/instancegroup": "test-ig",
+				}
 				kmp.Spec.KarpenterNodePoolsV1 = []infrastructurev1alpha1.KarpenterNodePoolsV1{
 					{
 						TypeMeta: metav1.TypeMeta{


### PR DESCRIPTION
Fixes missing cloud labels from KopsMachinePool in generated Karpenter EC2NodeClass resources.