### PR TITLE
Fix Terraform Plugin Cache Race Conditions with Enhanced Retry Logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v3.8.7
 CONTROLLER_TOOLS_VERSION ?= v0.16.4
-GOLANGCI_LINT_VERSION ?= v1.60.3
+GOLANGCI_LINT_VERSION ?= v2.5.0
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize
@@ -135,7 +135,7 @@ $(ENVTEST): $(LOCALBIN)
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary
 $(GOLANGCI_LINT): $(LOCALBIN)
-	test -s $(LOCALBIN)/golangci-lint || GOBIN=$(LOCALBIN) go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+	test -s $(LOCALBIN)/golangci-lint || GOBIN=$(LOCALBIN) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 
 # Development environment targets
 setup-dev-env: create-kind init-tilt

--- a/controllers/controlplane/kopscontrolplane_controller.go
+++ b/controllers/controlplane/kopscontrolplane_controller.go
@@ -184,7 +184,9 @@ func (r *KopsControlPlaneReconciler) PrepareCustomCloudResources(ctx context.Con
 		if err != nil {
 			return err
 		}
-		defer karpenterResourcesContent.Close()
+		defer func() {
+			_ = karpenterResourcesContent.Close()
+		}()
 
 		// This is needed because the apply will fail if the file is empty
 		placeholder := corev1.ConfigMap{

--- a/pkg/utils/kops_utils.go
+++ b/pkg/utils/kops_utils.go
@@ -367,7 +367,9 @@ func GetUserDataFromTerraformFile(clusterName, igName, terraformOutputDir string
 	if err != nil {
 		return "", err
 	}
-	defer userDataFile.Close()
+	defer func() {
+		_ = userDataFile.Close()
+	}()
 	userData, err := io.ReadAll(userDataFile)
 	if err != nil {
 		return "", err

--- a/pkg/utils/kops_utils_test.go
+++ b/pkg/utils/kops_utils_test.go
@@ -125,10 +125,10 @@ func TestParseSpotinstFeatureflags(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			os.Unsetenv("SPOTINST_TOKEN")
-			os.Unsetenv("SPOTINST_ACCOUNT")
+			_ = os.Unsetenv("SPOTINST_TOKEN")
+			_ = os.Unsetenv("SPOTINST_ACCOUNT")
 			for key, value := range tc.environmentVariables {
-				os.Setenv(key, value)
+				_ = os.Setenv(key, value)
 			}
 
 			err := ParseSpotinstFeatureflags(tc.input)

--- a/pkg/utils/terraform_utils_test.go
+++ b/pkg/utils/terraform_utils_test.go
@@ -222,7 +222,9 @@ func TestModifyTerraformProviderVersion(t *testing.T) {
 		t.Run(tc.description, func(t *testing.T) {
 			tmpDir, err := os.MkdirTemp("", "test_terraform_provider")
 			g.Expect(err).NotTo(HaveOccurred())
-			defer os.RemoveAll(tmpDir)
+			defer func() {
+				_ = os.RemoveAll(tmpDir)
+			}()
 
 			kubernetesFile := fmt.Sprintf("%s/kubernetes.tf", tmpDir)
 


### PR DESCRIPTION
### Problem
With 3 concurrent workers sharing the same Terraform plugin cache (/tmp/terraform_1.5.7/plugin-cache), we were experiencing frequent race conditions:
"text file busy" errors when multiple workers tried to install plugins simultaneously
Checksum mismatch errors when one worker validated cache while another was writing to it
"Required plugins are not installed" errors from corrupted cache state
### Solution
#### Retry Logic

- Increased retries from 3 to 5 attempts
- Implemented exponential backoff (1s, 2s, 4s, 8s, 16s) instead of linear
- Smart retry detection - only retries on known transient errors
- Automatic cache cleanup on checksum/corruption errors
