### PR TITLE
Switch CI workflows to self-hosted runners

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, arch:amd64]
     steps:
     - name: Checkout repo
       uses: actions/checkout@v4
@@ -26,7 +26,7 @@ jobs:
         args: --timeout 10m0s
 
   tests:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, arch:amd64]
     steps:
     - name: Checkout repo
       uses: actions/checkout@v4
@@ -45,7 +45,7 @@ jobs:
       run: make test-ci
 
   docker-build-amd64:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, arch:amd64]
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     needs:
     - tests
@@ -92,7 +92,7 @@ jobs:
         sbom: false
 
   docker-build-arm64:
-    runs-on: ubuntu-24.04-arm
+    runs-on: [self-hosted, arch:arm64]
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     needs:
     - tests
@@ -139,7 +139,7 @@ jobs:
         sbom: false
 
   docker-manifest:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, arch:amd64]
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     needs:
     - docker-build-amd64


### PR DESCRIPTION
## Summary
- Replace all GitHub-hosted runners (`ubuntu-latest`, `ubuntu-24.04-arm`) with org self-hosted runners
- `lint`, `tests`, `docker-build-amd64`, `docker-manifest` jobs use `[self-hosted, arch:amd64]`
- `docker-build-arm64` job uses `[self-hosted, arch:arm64]`

## Context
Self-hosted runners in `actions-runner-system` namespace were down due to an expired GitHub PAT. Token has been rotated and runners are back online.

## Test plan
- [ ] Verify `lint` and `tests` jobs pick up a self-hosted runner and pass
- [ ] Confirm runner pods in `actions-runner-system` show activity during the run

🤖 Generated with [Claude Code](https://claude.com/claude-code)