### PR TITLE
chore(renovate): Improve dependencies grouping and bump golang CI lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v3.8.7
 CONTROLLER_TOOLS_VERSION ?= v0.16.4
-GOLANGCI_LINT_VERSION ?= v2.5.0
+GOLANGCI_LINT_VERSION ?= v2.12.2
 
 ## setup-envtest is installed from the controller-runtime release branch that
 ## matches the sigs.k8s.io/controller-runtime version in go.mod. Using @latest

--- a/renovate.json
+++ b/renovate.json
@@ -40,15 +40,27 @@
   ],
   "packageRules": [
     {
-      "description": "Group the Go toolchain version wherever it is declared (go.mod, Dockerfile, .tool-versions) into a single PR so they never drift apart",
-      "matchPackageNames": ["go", "golang"],
-      "groupName": "golang toolchain"
+      "description": "Group the Go toolchain version wherever it is declared (go.mod, Dockerfile, .tool-versions) into a single PR so they never drift apart. matchDepNames is needed because the packageName differs per manager (go.mod: go, Dockerfile: golang, asdf: golang/go). rangeStrategy=bump opts in to go directive updates in go.mod, which Renovate skips by default.",
+      "matchDepNames": ["go", "golang"],
+      "groupName": "golang toolchain",
+      "rangeStrategy": "bump"
     },
     {
       "description": "Do not open PRs for Go indirect (transitive) dependencies. They are churny and are pulled in transitively via `go mod tidy` when a direct dep is bumped. Security fixes still come through via vulnerabilityAlerts.",
       "matchManagers": ["gomod"],
       "matchDepTypes": ["indirect"],
       "enabled": false
+    },
+    {
+      "description": "Terraform files under pkg/utils/fixtures are test input/expected-output pairs, not real dependencies. Bumping versions there breaks the HCL-manipulation unit tests.",
+      "matchManagers": ["terraform"],
+      "matchFileNames": ["pkg/utils/fixtures/**"],
+      "enabled": false
+    },
+    {
+      "description": "HashiCorp tooling is functionally coupled: terraform-exec uses hc-install to fetch the terraform binary. Bump them together.",
+      "matchPackageNames": ["github.com/hashicorp/**"],
+      "groupName": "hashicorp"
     },
     {
       "description": "Kubernetes staging libraries release in lockstep on a shared v0.x.y version - bump them together",


### PR DESCRIPTION
Improves Renovate Bot grouping of dependencies in order to:
- have a single PR for all Golang version references;
- ignore versions defined in the fixture folder;
- have a single PR for hashicorp related dependencies;

Also bumps the version of Golang CI lint library in the Makefile, as we already use it in the Github CI job. 